### PR TITLE
Bugfix/brca exchange syntax

### DIFF
--- a/R/brca-exchange-annotate-maf.R
+++ b/R/brca-exchange-annotate-maf.R
@@ -40,7 +40,7 @@ query_brca_exchange = function(gene, start, end, ref, alt, use_api = FALSE) {
             qq = brca_query(gene, start - 1, end + 1)
         } else {
             chrom = ifelse(gene == 'BRCA1', 17, 13)
-            qq = dplyr::filter(brca_exchange_variants, Chr == chrom, start - 1, end + 1) %>% 
+            qq = dplyr::filter(brca_exchange_variants, Chr == chrom, pyhgvs_Hg37_Start > start - 2, pyhgvs_Hg37_End < end + 2) %>%
                 purrr::transpose()
         }
         
@@ -103,8 +103,8 @@ brca_annotate_maf = function(maf, use_api = FALSE) {
     
     dplyr::mutate(maf, annot = purrr::pmap(list(Hugo_Symbol, Start_Position, End_Position, Reference_Allele, Tumor_Seq_Allele2, use_api),
                                            query_brca_exchange)) %>%
-        dplyr::mutate(brca_exchange_id = map_chr_possibly(annot, 'brca_exchange_id'),
-                      brca_exchange_enigma = map_chr_possibly(annot, 'brca_exchange_enigma'),
-                      brca_exchange_clinvar = map_chr_possibly(annot, 'brca_exchange_clinvar')) %>%
+        dplyr::mutate(brca_exchange_id = map_chr_possibly(annot, 'brca_exchange_id', .default = NA),
+                      brca_exchange_enigma = map_chr_possibly(annot, 'brca_exchange_enigma', .default = NA),
+                      brca_exchange_clinvar = map_chr_possibly(annot, 'brca_exchange_clinvar', .default = NA)) %>%
         dplyr::select(-annot)
 }

--- a/R/hotspot-annotate-maf.R
+++ b/R/hotspot-annotate-maf.R
@@ -18,14 +18,14 @@
 #' @name hotspot_annotate_maf
 NULL
 
-load_gene_annotation = function() {
-    read_lines('http://oncokb.org/api/v1/genes') %>%
+load_gene_annotation = function(oncokbbaseurl = 'https://legacy.oncokb.org/api/v1/genes') {
+    read_lines(oncokbbaseurl) %>%
         fromJSON()
 }
 
 #' @export
 #' @rdname hotspot_annotate_maf
-hotspot_annotate_maf = function(maf, hotspot_tbl = NULL) {
+hotspot_annotate_maf = function(maf, oncokbbaseurl = 'https://legacy.oncokb.org/api/v1/genes', hotspot_tbl = NULL) {
     
     if (!inherits(maf, 'data.frame')) stop('Input MAF must be a data frame, preferrable VEP annotated')
     if (!is.null(hotspot_tbl)) {
@@ -40,7 +40,7 @@ hotspot_annotate_maf = function(maf, hotspot_tbl = NULL) {
     if (any(grepl('hotspot', tolower(names(maf))))) message('Hotspot columns in MAF might be overwritten, check names')
     
     # Read default hotspot lists if user does not supply
-    gene_annotation = load_gene_annotation()
+    gene_annotation = load_gene_annotation(oncokbbaseurl)
 
     # Function that deals with indel hotspots
     tag_indel_hotspot = function(gene, hgvsp_short, start, end, indel_length) {


### PR DESCRIPTION
resolve #2 
resolve #5 
resolve #6 

Also found issues with `map_chr()`. Details here: 

https://github.com/taylor-lab/annotateMaf/issues/6#issuecomment-1020659758

This gives correct `brca_exchange_enigma` and `brca_exchange_clinvar` in final gremline maf. Previously, they are always empty